### PR TITLE
add dockerfile (tested on nvidia-gpu)

### DIFF
--- a/docker/nvidia-gpu/Dockerfile
+++ b/docker/nvidia-gpu/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.8.13
+
+ENV TZ=Asia/Tokyo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV DEBIAN_FRONTEND=noninteractive
+
+# NVIDIA -------------------------------------------------------------
+ENV NVIDIA_VISIBLE_DEVICES ${NVIDIA_VISIBLE_DEVICES:-all}
+ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
+
+# xserver ------------------------------------------------------------
+RUN apt update && apt -y upgrade && \
+apt install -y xserver-xorg && \
+apt -y clean && \
+rm -rf /var/lib/apt/lists/*
+
+# PyPI environment ---------------------------------------------------
+RUN pip install --upgrade pip
+
+# For error avoidance
+RUN pip install --upgrade cython numpy
+
+RUN pip install \
+opencv-python==4.5.5.64 \
+onnxruntime-gpu==1.11.1 \
+dearpygui==1.6.2 \
+mediapipe==0.8.10 \
+protobuf==3.20.0 \
+filterpy==1.4.5 \
+lap==0.4.0 \
+cython-bbox==0.1.3 \
+rich==12.4.4
+
+WORKDIR /workspace
+CMD ["python3", "main.py"]

--- a/docker/nvidia-gpu/README.md
+++ b/docker/nvidia-gpu/README.md
@@ -1,0 +1,39 @@
+# Dockerfile
+
+ベースとなる環境
+
+- Python3.8
+- Docker (Tested on NVIDIA-Docker2)
+- Webカメラ（/dev/video0に接続）
+- デスクトップPC (Intel CPU + NVIDIA RTX2080Ti)
+
+<br>
+
+## 構築
+
+```bash
+git clone https://github.com/Kazuhito00/Image-Processing-Node-Editor.git
+cd Image-Processing-Node-Editor/
+docker build docker/nvidia-gpu -t ipn_editor
+```
+
+<br>
+
+## 実行
+
+以下のコマンドで実行できました。一度終了すると、キャッシュは全て削除されるため、任意の外部フォルダをマウントしてください。
+
+```bash
+# cd /path-to-Image-Processing-Node-Editor
+xhost +
+docker run --rm -it　--privileged --device /dev/video0:/dev/video0:mwr -e DISPLAY=$DISPLAY -v $(pwd):/workspace --gpus all -v /tmp/.X11-unix:/tmp/.X11-unix ipn_editor
+# 勝手にウィンドウが開きます
+```
+
+### 使用したオプションについて
+
+- `--device /dev/video0:/dev/video0:mwr`: Webカメラを接続しない場合は取り除けます。
+- `--gpus all`: NVIDIA GPUでない場合は使用しないでください。
+- `-v $(pwd):/workspace`: [Image-Processing-Node-Editor](https://github.com/Kazuhito00/Image-Processing-Node-Editor)のマウント先です。
+  - オプションは、`Image-Processing-Node-Editor`ディレクトリ内で実行した場合です。
+  - マウント先は`/workspace`となります。


### PR DESCRIPTION
Added Dockefile for NVIDIA-Docker2.

## Tested environment

- NVIDIA RTX 2080Ti (driver version: 515.43.04)
- NVIDIA-Docker2 `Docker version 20.10.12, build 20.10.12-0ubuntu2~20.04.1`

## Docker environment

- Ubuntu 20.04 + Python3.8

:warning: At this time, CUDA is not supported because the presented environment doesn't include cuda