### PR TITLE
fix module cv2 has no attribute quality

### DIFF
--- a/docker/nvidia-gpu/Dockerfile
+++ b/docker/nvidia-gpu/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install --upgrade pip
 RUN pip install --upgrade cython numpy
 
 RUN pip install \
-opencv-python==4.5.5.64 \
+opencv-contrib-python==4.5.5.64 \
 onnxruntime-gpu==1.11.1 \
 dearpygui==1.6.2 \
 mediapipe==0.8.10 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.5.5.64
+opencv-contrib-python==4.5.5.64
 onnxruntime-gpu==1.11.1
 dearpygui==1.6.2
 mediapipe==0.8.10


### PR DESCRIPTION
### Error

```python
import cv2 as cv

...
score = cv2.quality.QualityBRISQUE_compute(image, model_path, range_path)
...

AttributeError: module 'cv2' has no attribute 'quality'
```

### Fix

```bash
pip uninstall opencv-python
pip install opencv-contrib-python
```